### PR TITLE
Feature/pickup highlight

### DIFF
--- a/IAmLegend/Assets/Prefabs/Bulldog Variant.prefab
+++ b/IAmLegend/Assets/Prefabs/Bulldog Variant.prefab
@@ -93,7 +93,7 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.5
-  m_Speed: 3.5
+  m_Speed: 3.75
   m_Acceleration: 2
   avoidancePriority: 50
   m_AngularSpeed: 120

--- a/IAmLegend/Assets/Prefabs/Player.prefab
+++ b/IAmLegend/Assets/Prefabs/Player.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 76237605}
   - component: {fileID: 76237606}
   m_Layer: 0
-  m_Name: Spot Light
+  m_Name: PlayerHeadLight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -47,98 +47,6 @@ Light:
   m_Range: 35
   m_SpotAngle: 75
   m_InnerSpotAngle: 7
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 0
-    m_Resolution: -1
-    m_CustomResolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingLayerMask: 1
-  m_Lightmapping: 4
-  m_LightShadowCasterMode: 0
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ColorTemperature: 6570
-  m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
---- !u!1 &981149636
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 981149637}
-  - component: {fileID: 981149638}
-  m_Layer: 0
-  m_Name: PlayerHeadLight
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &981149637
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 981149636}
-  m_LocalRotation: {x: -0.03409453, y: 0.15875936, z: 0.97288877, w: 0.16468313}
-  m_LocalPosition: {x: -14.73, y: 498.05, z: -428.89}
-  m_LocalScale: {x: 1, y: 0.76348, z: 3.6559005}
-  m_Children: []
-  m_Father: {fileID: 1217289233689839426}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: -18.671001, y: -0.85, z: 160.925}
---- !u!108 &981149638
-Light:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 981149636}
-  m_Enabled: 1
-  serializedVersion: 10
-  m_Type: 1
-  m_Shape: 0
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 2
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 0
@@ -371,39 +279,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4139521993327782, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 4154747179363686, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 4170614479340848, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 4251701110793002, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 4256355200966708, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4256858145242732, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 4302627559756474, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 4324579398271916, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4341381679720598, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 4372971402159412, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
@@ -411,71 +319,71 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4487238838887000, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 4499659601712094, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 4521526446233770, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4539364964484366, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4564865071621986, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 4599400366400192, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4605895408705184, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4637337702974308, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4680477166073756, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 4731101880813944, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 4739979767178390, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 4745259420538234, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 4793637345667360, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 4803766174332928, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4839042525702174, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 4887104802989636, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 4891331872491554, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 4955906993605542, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
@@ -483,7 +391,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4958916593883754, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 4990100130141130, guid: da9cdc9076b584147bdf535245f9454e, type: 3}
       propertyPath: m_RootOrder

--- a/IAmLegend/Assets/Prefabs/SM_Prop_HealthKit_01.fbx
+++ b/IAmLegend/Assets/Prefabs/SM_Prop_HealthKit_01.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68af014b5c54afdf98c5be6911dacaff096847e366c8d460768981e67d08bd5a
+size 32800

--- a/IAmLegend/Assets/Prefabs/SM_Prop_HealthKit_01.fbx.meta
+++ b/IAmLegend/Assets/Prefabs/SM_Prop_HealthKit_01.fbx.meta
@@ -1,0 +1,83 @@
+fileFormatVersion: 2
+guid: 56fc240b2e205b045aa8ca00e4093713
+timeCreated: 1566861275
+licenseType: Store
+ModelImporter:
+  serializedVersion: 19
+  fileIDToRecycleName:
+    100000: //RootNode
+    400000: //RootNode
+    2300000: //RootNode
+    3300000: //RootNode
+    4300000: SM_Prop_HealthKit_01
+    9500000: //RootNode
+  materials:
+    importMaterials: 0
+    materialName: 0
+    materialSearch: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    importBlendShapes: 0
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    optimizeMeshForGPU: 0
+    keepQuads: 0
+    weldVertices: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 5
+    normalImportMode: 1
+    tangentImportMode: 3
+  importAnimation: 0
+  copyAvatar: 0
+  humanDescription:
+    serializedVersion: 2
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    rootMotionBoneName: 
+    rootMotionBoneRotation: {x: 0, y: 0, z: 0, w: 1}
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  animationType: 0
+  humanoidOversampling: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IAmLegend/Assets/Prefabs/SimplePickupLight.prefab
+++ b/IAmLegend/Assets/Prefabs/SimplePickupLight.prefab
@@ -26,13 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1272766633744775646}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.02, z: 0}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!108 &1272766633744775647
 Light:
   m_ObjectHideFlags: 0
@@ -42,13 +42,13 @@ Light:
   m_GameObject: {fileID: 1272766633744775646}
   m_Enabled: 1
   serializedVersion: 10
-  m_Type: 2
+  m_Type: 0
   m_Shape: 0
   m_Color: {r: 0.50039995, g: 1, b: 0.3215686, a: 1}
-  m_Intensity: 3
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
+  m_Intensity: 2
+  m_Range: 4
+  m_SpotAngle: 40
+  m_InnerSpotAngle: 3
   m_CookieSize: 10
   m_Shadows:
     m_Type: 0
@@ -84,10 +84,10 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_RenderingLayerMask: 1
-  m_Lightmapping: 4
+  m_Lightmapping: 2
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
+  m_BounceIntensity: 0.8
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}

--- a/IAmLegend/Assets/Prefabs/SimplePickupLight.prefab
+++ b/IAmLegend/Assets/Prefabs/SimplePickupLight.prefab
@@ -1,0 +1,121 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1272766633744775646
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1272766633744775644}
+  - component: {fileID: 1272766633744775647}
+  - component: {fileID: -8093408458103945122}
+  - component: {fileID: -6852209189963649854}
+  m_Layer: 0
+  m_Name: SimplePickupLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1272766633744775644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272766633744775646}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.02, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!108 &1272766633744775647
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272766633744775646}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 2
+  m_Shape: 0
+  m_Color: {r: 0.50039995, g: 1, b: 0.3215686, a: 1}
+  m_Intensity: 3
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!114 &-8093408458103945122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272766633744775646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b552483ba13ac18b4992b4aad095ab39, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!65 &-6852209189963649854
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272766633744775646}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/IAmLegend/Assets/Prefabs/SimplePickupLight.prefab.meta
+++ b/IAmLegend/Assets/Prefabs/SimplePickupLight.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f373f75d8fabae7dda0b1671ae990a17
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IAmLegend/Assets/Prefabs/ZombieFastFemale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieFastFemale.prefab
@@ -320,7 +320,7 @@ Rigidbody:
   serializedVersion: 2
   m_Mass: 20
   m_Drag: 0
-  m_AngularDrag: 0
+  m_AngularDrag: 0.1
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -491,7 +491,7 @@ NavMeshAgent:
   m_GameObject: {fileID: 5505449400234868156}
   m_Enabled: 1
   m_AgentTypeID: 0
-  m_Radius: 0.2
+  m_Radius: 0.5
   m_Speed: 2.5
   m_Acceleration: 1
   avoidancePriority: 50

--- a/IAmLegend/Assets/Prefabs/ZombieFastFemale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieFastFemale.prefab
@@ -492,7 +492,7 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.5
-  m_Speed: 2.5
+  m_Speed: 3
   m_Acceleration: 1
   avoidancePriority: 50
   m_AngularSpeed: 120

--- a/IAmLegend/Assets/Prefabs/ZombieFastMale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieFastMale.prefab
@@ -271,7 +271,7 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.5
-  m_Speed: 2.5
+  m_Speed: 3
   m_Acceleration: 1
   avoidancePriority: 50
   m_AngularSpeed: 120

--- a/IAmLegend/Assets/Prefabs/ZombieFastMale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieFastMale.prefab
@@ -99,7 +99,7 @@ Rigidbody:
   serializedVersion: 2
   m_Mass: 20
   m_Drag: 0
-  m_AngularDrag: 0
+  m_AngularDrag: 0.1
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -270,7 +270,7 @@ NavMeshAgent:
   m_GameObject: {fileID: 1789882594217064594}
   m_Enabled: 1
   m_AgentTypeID: 0
-  m_Radius: 0.2
+  m_Radius: 0.5
   m_Speed: 2.5
   m_Acceleration: 1
   avoidancePriority: 50

--- a/IAmLegend/Assets/Prefabs/ZombieSlowFemale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieSlowFemale.prefab
@@ -381,7 +381,7 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.5
-  m_Speed: 1
+  m_Speed: 3
   m_Acceleration: 1
   avoidancePriority: 50
   m_AngularSpeed: 120

--- a/IAmLegend/Assets/Prefabs/ZombieSlowFemale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieSlowFemale.prefab
@@ -209,7 +209,7 @@ Rigidbody:
   serializedVersion: 2
   m_Mass: 20
   m_Drag: 0
-  m_AngularDrag: 0
+  m_AngularDrag: 0.1
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -380,7 +380,7 @@ NavMeshAgent:
   m_GameObject: {fileID: 6926614120133566439}
   m_Enabled: 1
   m_AgentTypeID: 0
-  m_Radius: 0.2
+  m_Radius: 0.5
   m_Speed: 1
   m_Acceleration: 1
   avoidancePriority: 50

--- a/IAmLegend/Assets/Prefabs/ZombieSlowMale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieSlowMale.prefab
@@ -460,7 +460,7 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.5
-  m_Speed: 1
+  m_Speed: 3
   m_Acceleration: 1
   avoidancePriority: 50
   m_AngularSpeed: 120

--- a/IAmLegend/Assets/Prefabs/ZombieSlowMale.prefab
+++ b/IAmLegend/Assets/Prefabs/ZombieSlowMale.prefab
@@ -321,7 +321,7 @@ Rigidbody:
   serializedVersion: 2
   m_Mass: 20
   m_Drag: 0
-  m_AngularDrag: 0
+  m_AngularDrag: 0.1
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -459,7 +459,7 @@ NavMeshAgent:
   m_GameObject: {fileID: 2480364867448177705}
   m_Enabled: 1
   m_AgentTypeID: 0
-  m_Radius: 0.2
+  m_Radius: 0.5
   m_Speed: 1
   m_Acceleration: 1
   avoidancePriority: 50

--- a/IAmLegend/Assets/Scenes/main.unity
+++ b/IAmLegend/Assets/Scenes/main.unity
@@ -1817,7 +1817,7 @@ Transform:
   - {fileID: 1649701082}
   - {fileID: 1762760325}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &114140682 stripped
 Transform:
@@ -7816,7 +7816,7 @@ Transform:
   - {fileID: 1294682493}
   - {fileID: 1254708987}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519229401
 GameObject:
@@ -18434,7 +18434,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1145088576 stripped
 Transform:
@@ -19101,7 +19101,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1179826255 stripped
 GameObject:
@@ -22111,7 +22111,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1386506936
 MonoBehaviour:
@@ -22139,15 +22139,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   weaponPickups:
-  - {fileID: 1920583333783314424, guid: 4e8f2589bcb966a14a02a79ebef7e350, type: 3}
-  - {fileID: 2651629564291913989, guid: 6b145e48b1e426ce59c8f070fd54b90b, type: 3}
   - {fileID: 4545513176930560763, guid: e855fb798f00669fdba5feb2ac6d0bc6, type: 3}
-  minWeaponsEach: 5
-  maxWeaponsEach: 20
+  - {fileID: 2651629564291913989, guid: 6b145e48b1e426ce59c8f070fd54b90b, type: 3}
+  minWeaponsEach: 10
+  maxWeaponsEach: 30
   healthPickups:
   - {fileID: 1482962199089960272, guid: 77df9bf80182dc7c29ad40ca8b2ee132, type: 3}
-  minHealthItems: 40
-  maxHealthItems: 70
+  minHealthItems: 70
+  maxHealthItems: 120
+  pickupHighlight: {fileID: 1272766633744775646, guid: f373f75d8fabae7dda0b1671ae990a17,
+    type: 3}
   maxPosAxisX: 950
   maxPosAxisZ: 900
 --- !u!4 &1389277130 stripped
@@ -24479,7 +24480,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 65, y: 0, z: 0}
 --- !u!114 &1530326829
 MonoBehaviour:
@@ -29043,7 +29044,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1855191476 stripped
 Transform:
@@ -31033,6 +31034,75 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 93caadf4359ae8143aad35b3145d31af, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4471b1f7f824e4d44887e1364c6fc61a, type: 3}
+--- !u!1001 &2002302281
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 496.722
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 502.648
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775646, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_Name
+      value: SimplePickupLight
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f373f75d8fabae7dda0b1671ae990a17, type: 3}
 --- !u!4 &2004280414 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5440707293445741943, guid: 494f6d43e170e9145bc7865d243ee00b,

--- a/IAmLegend/Assets/Scenes/main.unity
+++ b/IAmLegend/Assets/Scenes/main.unity
@@ -22147,12 +22147,12 @@ MonoBehaviour:
   weaponPickups:
   - {fileID: 4545513176930560763, guid: e855fb798f00669fdba5feb2ac6d0bc6, type: 3}
   - {fileID: 2651629564291913989, guid: 6b145e48b1e426ce59c8f070fd54b90b, type: 3}
-  minWeaponsEach: 10
-  maxWeaponsEach: 30
+  minWeaponsEach: 20
+  maxWeaponsEach: 55
   healthPickups:
   - {fileID: 1482962199089960272, guid: 77df9bf80182dc7c29ad40ca8b2ee132, type: 3}
-  minHealthItems: 70
-  maxHealthItems: 120
+  minHealthItems: 150
+  maxHealthItems: 300
   pickupHighlight: {fileID: 1272766633744775646, guid: f373f75d8fabae7dda0b1671ae990a17,
     type: 3}
   maxPosAxisX: 950
@@ -31061,37 +31061,37 @@ PrefabInstance:
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.042
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.6480103
+      value: 2.767
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
@@ -31107,6 +31107,31 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: SimplePickupLight
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775647, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_Range
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775647, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_Intensity
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775647, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_SpotAngle
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775647, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_Lightmapping
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1272766633744775647, guid: f373f75d8fabae7dda0b1671ae990a17,
+        type: 3}
+      propertyPath: m_BounceIntensity
+      value: 0.8
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f373f75d8fabae7dda0b1671ae990a17, type: 3}

--- a/IAmLegend/Assets/Scenes/main.unity
+++ b/IAmLegend/Assets/Scenes/main.unity
@@ -1817,7 +1817,7 @@ Transform:
   - {fileID: 1649701082}
   - {fileID: 1762760325}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &114140682 stripped
 Transform:
@@ -7816,7 +7816,7 @@ Transform:
   - {fileID: 1294682493}
   - {fileID: 1254708987}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519229401
 GameObject:
@@ -18434,7 +18434,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1145088576 stripped
 Transform:
@@ -19101,7 +19101,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1179826255 stripped
 GameObject:
@@ -21416,6 +21416,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2024700669}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1340169750 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
+    type: 3}
+  m_PrefabInstance: {fileID: 2002302281}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1345819819 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2656863232278807161, guid: 6b145e48b1e426ce59c8f070fd54b90b,
@@ -22111,7 +22117,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1386506936
 MonoBehaviour:
@@ -24480,7 +24486,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 65, y: 0, z: 0}
 --- !u!114 &1530326829
 MonoBehaviour:
@@ -26468,6 +26474,7 @@ Transform:
   - {fileID: 1440821499}
   - {fileID: 1345819819}
   - {fileID: 1804820810}
+  - {fileID: 1340169750}
   m_Father: {fileID: 113465040}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -29044,7 +29051,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1855191476 stripped
 Transform:
@@ -31039,27 +31046,27 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1649701082}
     m_Modifications:
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 496.722
+      value: 0.0019848347
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.02
+      value: -0.042
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 502.648
+      value: 2.6480103
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
@@ -31069,17 +31076,17 @@ PrefabInstance:
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 1272766633744775644, guid: f373f75d8fabae7dda0b1671ae990a17,
         type: 3}

--- a/IAmLegend/Assets/Scripts/PickupSpawner.cs
+++ b/IAmLegend/Assets/Scripts/PickupSpawner.cs
@@ -15,6 +15,9 @@ public class PickupSpawner : MonoBehaviour
     [SerializeField] private int minHealthItems;
     [SerializeField] private int maxHealthItems;
 
+    [Header("Pickup Highlight")]
+    [SerializeField] private GameObject pickupHighlight;
+
     [Header("Terrain Size")]
     // Max position of the terrain for spawning locations
     [SerializeField] private float maxPosAxisX;
@@ -36,10 +39,12 @@ public class PickupSpawner : MonoBehaviour
         {
             foreach(GameObject _item in _items)
             {
-                // Generate random position for the item
-                Vector3 _spawnPos = new Vector3(Random.Range(0, _maxPosAxisX), _item.transform.position.y, Random.Range(0, _maxPosAxisZ));
+                // Generate random position for the item and its highlight
+                Vector3 _itemSpawnPos = new Vector3(Random.Range(0, _maxPosAxisX), _item.transform.position.y, Random.Range(0, _maxPosAxisZ));
+                Vector3 _highlightSpawnPos = new Vector3(_itemSpawnPos.x, pickupHighlight.transform.position.y, _itemSpawnPos.z);
 
-                Instantiate(_item, _spawnPos, transform.rotation);
+                Instantiate(_item, _itemSpawnPos, _item.transform.rotation);
+                Instantiate(pickupHighlight, _highlightSpawnPos, pickupHighlight.transform.rotation);
             }
         }
     }

--- a/IAmLegend/Assets/Scripts/SimplePickupLight.cs
+++ b/IAmLegend/Assets/Scripts/SimplePickupLight.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SimplePickupLight : MonoBehaviour
+{
+    void OnTriggerEnter( Collider other )
+    {   
+        // Destroy the object when the player enters into it
+        if(other.tag == "Player")
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/IAmLegend/Assets/Scripts/SimplePickupLight.cs.meta
+++ b/IAmLegend/Assets/Scripts/SimplePickupLight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b552483ba13ac18b4992b4aad095ab39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Since Unity doesn't recommend changing shaders in runtime, this is a workaround to highlight pickups.